### PR TITLE
Added pairs sizing command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# User-generated items 
+*.png
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Available commands:
 ```
 tw plot                chart your portfolio's net liquidity or profit/loss over time
 tw quant               mathematical and statistical analysis
+tw pairs               analyze and size pairs trades
 ```
 Unavailable commands pending development:
 ```
@@ -27,7 +28,7 @@ tw future              buy, sell, and analyze futures
 tw stock               buy, sell, and analyze stock
 tw option              buy, sell, and analyze options
 ```
-For more options, run `tw --help`.
+For more options, run `tw --help` or `tw <subcommand> --help`.
 
 ## Development/Contributing
 
@@ -37,6 +38,12 @@ Creating a virtualenv for development:
 ```
 $ make venv
 $ source env/bin/activate
+```
+
+...after building the environment, will need to install the package: 
+
+```
+pip install . 
 ```
 
 It's usually a good idea to make sure you're passing tests locally before submitting a PR:

--- a/src/app.py
+++ b/src/app.py
@@ -2,6 +2,7 @@ import click
 
 from .future.commands import future
 from .option.commands import option
+from .pairs.commands import pairs
 from .plot.commands import plot
 from .utils import VERSION
 
@@ -16,5 +17,6 @@ def main():
     app.add_command(future)
     app.add_command(option)
     app.add_command(plot)
+    app.add_command(pairs)
 
     app()

--- a/src/pairs/commands.py
+++ b/src/pairs/commands.py
@@ -1,0 +1,69 @@
+import click
+
+from .sizing import size as size_pair
+
+
+def summarize(pair_specs):
+    """Summarize pairs calculation"""
+    print(f"\nFor {pair_specs['unit_size_right']:,.2f} units in the left "
+          f"leg, trade {pair_specs['unit_size_left']:,.2f} in the right "
+          f"leg. \n")
+
+
+@click.group(chain=True, help='Evaluate and size pairs trades.')
+def pairs():
+    pass
+
+
+@pairs.command(help='Calculate volatility-weighted size for each leg. ')
+@click.option('-i', '--interactive-mode', is_flag=True,
+              help='Query inputs from user.')
+@click.option('-l', '--price-left', type=float, default=1,
+              help='Price of left leg.')
+@click.option('-r', '--price-right', type=float, default=1,
+              help='Price of right leg.')
+@click.option('-v', '--vol-left', type=float, default=1,
+              help='Volatility measure of left leg.')
+@click.option('-o', '--vol-right', type=float, default=1,
+              help='Volatility measure of right leg.')
+@click.option('-s', '--unit-size-left', type=float, default=1,
+              help='Number of units for left leg.')
+@click.option('-m', '--multiplier-left', type=float, default=1,
+              help='Unit multplier for left leg.')
+@click.option('-u', '--multiplier-right', type=float, default=1,
+              help='Unit multplier for right leg.')
+def size(interactive_mode, price_left, price_right, vol_left, vol_right,
+         unit_size_left, multiplier_left, multiplier_right):
+    if interactive_mode:
+        args = dict()
+        args['unit_size_left'] = 1
+        args['multiplier_left'] = 1
+        args['multiplier_right'] = 1
+        c = ['unit_size_left', 'price_left', 'vol_left', 'multiplier_left',
+             'price_right', 'vol_right', 'multiplier_right', ]
+        for k in c:
+            if k in args:
+                v = input(f"enter value for {k} (default={args[k]:.2f}) > ")
+                if v:
+                    args[k] = float(v)
+            else:
+                args[k] = float(input(f"enter value for {k} > "))
+        pair_specs = size_pair(**args)
+        summarize(pair_specs)
+        print('Below are the arguments to replicate: \n')
+        print(
+            f"    tw pairs size "
+            f"-s {pair_specs['unit_size_left']:.2f} "
+            f"-l {pair_specs['price_left']:.2f} "
+            f"-v {pair_specs['vol_left']:.2f} "
+            f"-m {pair_specs['multiplier_left']:.2f} "
+            f"-r {pair_specs['price_right']:.2f} "
+            f"-o {pair_specs['vol_right']:.2f} "
+            f"-u {pair_specs['multiplier_right']:.2f} \n"
+        )
+
+    else:
+        pair_specs = size_pair(price_left, price_right, vol_left, vol_right,
+                               unit_size_left, multiplier_left,
+                               multiplier_right)
+        summarize(pair_specs)

--- a/src/pairs/sizing.py
+++ b/src/pairs/sizing.py
@@ -104,10 +104,6 @@ def size(price_left=1, price_right=1, vol_left=1, vol_right=1, unit_size_left=1,
         (vol_left * price_left * multiplier_left * unit_size_left) / \
         (vol_right * price_right * multiplier_right)
 
-    msg = 'Volatility-weighted equity should equate.'
-    assert vol_left * price_left * multiplier_left * unit_size_left == \
-        vol_right * price_right * multiplier_right * unit_size_right, msg
-
     pair_specs = dict(vol_left=vol_left, price_left=price_left,
                       multiplier_left=multiplier_left,
                       multiplier_right=multiplier_right,

--- a/src/pairs/sizing.py
+++ b/src/pairs/sizing.py
@@ -1,0 +1,117 @@
+"""Funcs to calculate size of pair"""
+
+
+def size(price_left=1, price_right=1, vol_left=1, vol_right=1, unit_size_left=1,
+         multiplier_left=1, multiplier_right=1):
+    """Calculate volatility weighted size for each leg of pairs trade
+
+    Calculate the number of units for each leg of a pairs trade by
+    passing the price of both legs and optionally the share size of one
+    leg and multipliers in the case of futures. Returns a dict with the
+    given arguments and the number of units for each leg.
+
+    It is often desirable to equate the level of risk for each leg of a
+    pairs trade. This risk depends on both the equity value and the
+    volatility of each leg.
+
+    For example, suppose a pairs trade consists of two legs. The first
+    leg is long stock ABC, which trades for $100 per share and has a
+    30-day historical standard deviation of 2%. The second leg is a
+    short position in stock XYZ, which trades for $25 per share and has
+    a standard deviation of 7%. How many shares of each stock should be
+    traded to create a neutral pairs trade?
+
+    Clearly, if 100 shares of each leg were traded, the risk in one leg
+    would be much greater than the other. So, we want to equate the
+    equity of each leg:
+
+        abc_shares * abc_price = xyz_shares * xyz_price
+        left_shares * left_price = right_shares * right_price
+
+    ...where we have arbitrarily defined ABC as the "left" side of the
+    trade.
+
+    However, the above equation fails to adequately equate the risk in
+    each leg; since the volatility of XYZ is 7% and the volatility of
+    ABC is 2%, sizing the trade based on the above equation would put
+    more risk in the XYZ leg than the ABC leg.
+
+    So, to equate the risk in each leg, we add a measure of volatility
+    to the prior equation:
+
+        left_shares * left_price * left_vol = right_shares * right_price * right_vol
+
+    Compared to the prior equation, this equation reduces the number of
+    shares traded in XYZ, since the risk is larger in each unit of
+    equity for XYZ, because XYZ has higher volatility.
+
+    Now, suppose that we're comfortable trading 100 shares of ABC and we
+    want to now calculate the quantity of XYZ shares to trade. We can do
+    a simple algebriac manipulation to calculate the number of shares:
+
+        right_shares = (left_shares * left_price * left_vol) / (right_price * right_vol)
+                     = (100 * 100 * 2) / (25 * 7)
+                     = 114.28
+
+    ..and this can be plugged back into the original equation as a
+    check.
+
+    In the case of a futures contract, the *notional value* must be
+    calculated in order to volatility-weight each leg:
+
+        left_units * left_multiplier * left_price * left_vol =
+            right_units * right_multiplier * right_price * right_vol
+
+    ...where the multiplier is a number used to convert the futures
+    price into the notional value of the futures contract. In the case
+    where both legs are a stock, the multipliers are simply 1. To
+    calculate the number of units for the right leg:
+
+        left_units =
+            (right_units * right_multiplier * right_price * right_vol) /
+            (left_multiplier * left_price * left_vol)
+
+    Parameters
+    ----------
+    price_left, price_right : float
+        The entry prices for each leg of the pair, left and right.
+
+    vol_left, vol_right : float
+        A measure of volatility for each leg of the pair, left and
+        right.
+
+    unit_size_left : float
+        The number of units (e.g. shares) that compose the left leg of
+        the pair. Optional, default is 1 unit.
+
+    multiplier_left, multiplier_right : float
+        Multiplier for each leg of the pair, left and right. The
+        multiplier is a number that translates the asset price into the
+        notional (equity) value of one unit of the asset. In the case of
+        a stock, the mulitplier is simply 1. The multiplier for futures
+        contracts depends on the specifications of the contract.
+        Optional, default is 1.
+
+    Returns
+    -------
+    pair_specs : dict
+        Dict with keys multiplier_left, multiplier_right, price_left,
+        price_right, unit_size_left, unit_size_right, vol_left,
+        and vol_right.
+
+    """
+    unit_size_right = \
+        (vol_left * price_left * multiplier_left * unit_size_left) / \
+        (vol_right * price_right * multiplier_right)
+
+    msg = 'Volatility-weighted equity should equate.'
+    assert vol_left * price_left * multiplier_left * unit_size_left == \
+        vol_right * price_right * multiplier_right * unit_size_right, msg
+
+    pair_specs = dict(vol_left=vol_left, price_left=price_left,
+                      multiplier_left=multiplier_left,
+                      multiplier_right=multiplier_right,
+                      unit_size_left=unit_size_left, vol_right=vol_right,
+                      price_right=price_right, unit_size_right=unit_size_right)
+
+    return pair_specs

--- a/tests/test_pairs.py
+++ b/tests/test_pairs.py
@@ -1,0 +1,32 @@
+from math import floor
+
+from src.pairs import sizing
+
+
+def test_sizing():
+    """Apply test cases for pairs sizing"""
+
+    args = dict(price_left=100, price_right=25, vol_left=2, vol_right=7,
+                unit_size_left=100, multiplier_left=1, multiplier_right=1)
+
+    def msg():
+        return f"Expected {exp:.2f} units, but calculated {act:.2f}."
+
+    pair_specs = sizing.size(**args)
+    exp = 114
+    act = floor(pair_specs['unit_size_right'])
+    assert act == exp, msg()
+
+    args['multiplier_left'] = 100
+    args['multiplier_right'] = 10
+    pair_specs = sizing.size(**args)
+    exp = 1142
+    act = floor(pair_specs['unit_size_right'])
+    assert act == exp, msg()
+
+    args['multiplier_left'] = 1
+    args['multiplier_right'] = 100
+    pair_specs = sizing.size(**args)
+    exp = 1.14
+    act = round(pair_specs['unit_size_right'], 2)
+    assert act == exp, msg()


### PR DESCRIPTION
Added functionality for calculating volatility-weighted unit size for a
pairs trade. Folder `src/pairs` was created and module `sizing` was
added, along with supporting `commands` module.

Added test case for `sizing.py`.

Made minor edits to README.

Added line `*.png` to `.gitignore` to suppress png files from git
tracking.