### PR TITLE
update aiocometd (fix #27)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+git+https://github.com/Graeme22/aiocometd@0.4.5.3#egg=aiocometd
 anyio==3.5.0
 asyncclick==8.0.3.2
 flake8==4.0.1

--- a/twcli/utils.py
+++ b/twcli/utils.py
@@ -115,12 +115,12 @@ def get_confirmation(prompt: str) -> bool:
 
 
 async def get_account(sesh: RenewableTastyAPISession) -> TradingAccount:
-    account = os.getenv('TW_ACC')
+    account = sesh.config['general'].get('default-account', None)
     if account:
         for acc in sesh.accounts:
             if acc.account_number == account:
                 return acc
-        LOGGER.warning('Environment variable $TW_ACC is set, but the account doesn\'t appear to exist!')
+        LOGGER.warning('Default account is set, but the account doesn\'t appear to exist!')
 
     for i in range(len(sesh.accounts)):
         if i == 0:


### PR DESCRIPTION
# Problem addressed

`aiocometd` is no longer maintained, and now Python 3.10 users will see breakage (#27).

# Solution

`requirements.txt` now uses my fork of `aiocometd` which fixes the breakage.

# Checklist

- PR commits have been squashed
- All tests pass
